### PR TITLE
Fix Chrome 61 Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function detectScrollElem() {
     return document.documentElement;
   }
   // Chrome (non-standard)
-  return document.body;
+  return document.scrollingElement || document.body;
 }
 
 module.exports = function scrollDoc() {


### PR DESCRIPTION
Code doesn't work with Chrome 61. Fixed by using document.scrollingElement